### PR TITLE
Fix deprecated Unparenthesized `a ? b : c ? d : e`

### DIFF
--- a/src/EasyCache.php
+++ b/src/EasyCache.php
@@ -322,7 +322,7 @@ class EasyCache {
 	 * @return {Number}
 	 */
 	private function within($number, $min, $max) {
-		return $number < $min ? $min : $number > $max ? $max : $number;
+		return ($number < $min) ? $min : ($number > $max ? $max : $number);
 	}
 
 	/**


### PR DESCRIPTION
PHP Error : Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`